### PR TITLE
Port to 26.1.2

### DIFF
--- a/spigot/pom.xml
+++ b/spigot/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>com.lukeonuke</groupId>
     <artifactId>fast-leaf-decay</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
 
     <name>fast-leaf-decay</name>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -67,18 +67,18 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.21-R0.1-SNAPSHOT</version>
+            <version>26.1.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>24.0.1</version>
+            <version>26.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.32</version>
+            <version>1.18.46</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/spigot/src/main/java/com/lukeonuke/fastleafdecay/event/BlockBreakEventListener.java
+++ b/spigot/src/main/java/com/lukeonuke/fastleafdecay/event/BlockBreakEventListener.java
@@ -1,10 +1,8 @@
 package com.lukeonuke.fastleafdecay.event;
 
-import com.lukeonuke.fastleafdecay.FastLeafDecay;
 import com.lukeonuke.fastleafdecay.service.ConfigurationService;
 import com.lukeonuke.fastleafdecay.service.TaxicabDistanceService;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
+
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;

--- a/spigot/src/main/resources/plugin.yml
+++ b/spigot/src/main/resources/plugin.yml
@@ -1,5 +1,9 @@
 name: fast-leaf-decay
 version: '${project.version}'
 main: com.lukeonuke.fastleafdecay.FastLeafDecay
-api-version: '1.20'
+api-version: '26.1.2'
 folia-supported: true
+description: A fast leaf decay plugin for Spigot and Paper servers.
+author: LukeOnuke
+contributors: [ElectricSteve]
+website: https://github.com/LukeOnuke/fast-leaf-decay/


### PR DESCRIPTION
closes #5 
This is a simple port, but it seems to work correctly.

I would also recommend switching to gradle for the spigot project since I don't really like maven.